### PR TITLE
updates success message to be a bit more descriptive

### DIFF
--- a/www/components/SignUpForm.js
+++ b/www/components/SignUpForm.js
@@ -84,7 +84,7 @@ const SignUpForm = ({ className }) => (
           .then(
             setStatus({
               success:
-                'Thank you for signing up. Please watch your email for an invitation to THAT Slack.'
+                'Thank you for signing up. Your request has been submitted and is under review. Please watch your email for an invitation to THAT Slack.'
             })
           )
           .then(nprogress.done())


### PR DESCRIPTION
people are double signing up and I'm guessing it's because they feel like they're not getting signed up instantly. 